### PR TITLE
Add "@inject-into" meta key support for Violent Monkey users

### DIFF
--- a/src/shared/meta.ts
+++ b/src/shared/meta.ts
@@ -74,6 +74,9 @@ export const META_FIELDS_STRING = [
   "downloadURL",
   "supportURL",
   "unwrap",
+  // Only valid for Violent Monkey @see {@link https://violentmonkey.github.io/api/metadata-block/#inject-into}
+  "inject-into", 
+  "injectInto"
 ] as const
 
 export const META_FIELDS = [
@@ -89,4 +92,5 @@ export const META_FIELD_ALIAS: {
   [K in keyof Meta]?: ConditionalKeys<Meta, Meta[K]>
 } = {
   runAt: "run-at",
+  injectInto: "inject-into",
 }

--- a/tests/cases/basic/__snapshots__/basic.test.ts/build-1.txt
+++ b/tests/cases/basic/__snapshots__/basic.test.ts/build-1.txt
@@ -1,9 +1,10 @@
 // ==UserScript==
-// @name     Hello world
-// @grant    GM_log
-// @match    *://*/*
-// @version  1.0.0
-// @run-at   document-end
+// @name         Hello world
+// @grant        GM_log
+// @match        *://*/*
+// @version      1.0.0
+// @run-at       document-end
+// @inject-into  content
 // ==/UserScript==
 
 ;(() => {

--- a/tests/cases/basic/meta.js
+++ b/tests/cases/basic/meta.js
@@ -2,6 +2,6 @@ module.exports = {
   name: "Hello world",
   version: "1.0.0",
   match: ["*://*/*"],
-  'run-at': "document-start",
   runAt: "document-end",
+  'inject-into': "content"
 }


### PR DESCRIPTION
Firstly, thanks for this plugin. Finally, I have a tool that allows me to manage my UserScripts in a truly efficient manner!

Regarding the PR: the current meta implementation is missing support for the `@inject-into` meta key, which was introduced by [Violent Monkey](https://violentmonkey.github.io/api/metadata-block/#inject-into).

To address this, I've replicated the structure of the `run-at` meta key and included support for `inject-into` along with its alias: `injectInto`.

Additionally, I've enhanced the basic test suite by replacing `run-at` with `inject-into` to ensures that both the alias and non-alias use cases are thoroughly examined, with `runAt` covering the alias scenario and `inject-into` testing the non-alias scenario. I suppose the double `@run-at` meta key was to test this scenario and not the key override.
