### PR TITLE
fix: package paths and add npm prepare script

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - run: npm ci
-      - run: npm run build
       - run: npm publish ./dist
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "test:tm": "cross-env EXT=tampermonkey playwright test",
     "test:vm": "cross-env EXT=violentmonkey playwright test",
     "test:tm:d": "npm run test:tm -- --debug --headed",
-    "test:tm:ui": "npm run test:tm -- --ui --headed"
+    "test:tm:ui": "npm run test:tm -- --ui --headed",
+    "prepare": "npm run build"
   },
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "dist/lib/index.js",
+  "types": "dist/lib/index.d.ts",
   "files": [
-    "lib",
+    "dist",
     "README.md"
   ],
   "repository": {


### PR DESCRIPTION
This PR improves the npm workflow by using the standard `prepare` lifecycle script and moves the package entry point paths from `lib/` to `dist/lib/`. Now, you can install it directly from GitHub using npm install.

To test it, install my fork directly by running:
```bash
npm install https://github.com/Giglium/webpack-monkey.git
```